### PR TITLE
mamifest: add dts_root in settings

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -14,4 +14,4 @@ build:
     # Zephyr will use the `<dts_root>/dts` for additional dts files and
     # `<dts_root>/dts/bindings` for additional dts binding files. The `.` is
     # the root of this repository.
-    # dts_root: .
+    dts_root: .


### PR DESCRIPTION
If not add something in settings,  west build would fail.