### PR TITLE
manifest: use latest version of zephyr and hal

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,7 +13,7 @@ manifest:
   projects:
     - name: zephyr
       remote: rtkconnectivity
-      revision: v3.7-rtk-00.01.01
+      revision: realtek-main-v3.7
       import:
         name-allowlist:
           - cmsis
@@ -21,13 +21,3 @@ manifest:
           - tinycrypt
           - openthread
           - mbedtls
-
-    #
-    # Realtek based overrides of Zephyr modules and additional
-    # added modules
-    #
-    - name: hal_realtek
-      revision: a0a394a583ab8f0c37d56aefa65da834fe411878
-      path: modules/hal/realtek
-      groups:
-        - hal


### PR DESCRIPTION
Not a release version, so change its dependency to the latest version.